### PR TITLE
Fix label height and add new fitted label

### DIFF
--- a/prisma-flow-diagram/prisma-flow-diagram.sty
+++ b/prisma-flow-diagram/prisma-flow-diagram.sty
@@ -16,7 +16,7 @@
     },
     ml/.style args={#1/#2}{
         draw, rectangle, align=center, rounded corners, font=\small\bfseries, inner sep=2ex, 
-        outer sep=0pt, fill=cyan!30, minimum height=1.6*\mh, left=5mm of #2
+        outer sep=0pt, fill=cyan!30, minimum height=#1, left=5mm of #2
     },
     arrow/.style={
         thick,->,>=stealth
@@ -42,6 +42,45 @@
 % Add a left-side label
 \newcommand{\prismalabel}[3]{
     \node[ml=#1/#2] {\rotatebox{90}{\textbf{#3}}};
+}
+
+% Add fitted left-side label
+\newcommand{\prismalabelfitted}[5]{%
+% #1 = name
+% #2 = left reference node (for x-position)
+% #3 = top right-side node (for top y)
+% #4 = bottom right-side node (for bottom y)
+% #5 = text
+\node[
+    draw,
+    rounded corners,
+    fill=cyan!30,
+    inner sep=0pt,
+    outer sep=0pt,
+    minimum width=8mm,
+    text width=8mm,
+    align=center
+] (#1) at ($(#2.west)+(-9mm,0)$)
+{\rotatebox{90}{\textbf{#5}}};
+
+\path let
+    \p1 = (#3.north),
+    \p2 = (#4.south),
+    \p3 = (#1.center)
+in
+node[
+    draw,
+    rounded corners,
+    fill=cyan!30,
+    inner sep=0pt,
+    outer sep=0pt,
+    minimum width=8mm,
+    text width=8mm,
+    align=center,
+    anchor=center,
+    minimum height={\y1-\y2}
+] at (\x3,{(\y1+\y2)/2})
+{\rotatebox{90}{\textbf{#5}}};
 }
 
 % Add a manual arrow


### PR DESCRIPTION
Previously, argument #1 of the label height had not been used; hence, all labels had the same height. This has been fixed now. In addition, I added a new label version that adjusts its length to cover multiple nodes. This allows to create [PRISMA 2020](https://www.prisma-statement.org/prisma-2020) diagrams. Please find an example below:

```
\begin{figure}[H]
\resizebox{\textwidth}{!}{
\prismaflowstart

% Left column
\prismaflownode{n1}{left=of tc}{
Records identified from: \\
\hspace*{5mm} Scopus (n = 192)
}{};

\prismaflownode{n2}{below=3cm of n1}{
Records screened \\ (titel and abstract screening): (n = 190)
}{n1};

\prismaflownode{n3}{below=2.25 cm of n2}{
Reports sought for retrieval: (n = 62)
}{n2};

\prismaflownode{n4}{below=1.7cm of n3}{
Reports assessed for eligibility \\ (full text screening): (n = 62)
}{n3};

\prismaflownode{n5}{below=1.8cm of n4}{
Studies included in review: (n = 47) \\
Reports of included studies: (n = 47)
}{n4};

% Right column - pushed further right to avoid overlaps
\prismaflownode{n1r}{right=2.5cm of n1}{
Records removed before screening (n = 2): \\
\hspace*{5mm} Duplicate records removed (n = 2) \\
\hspace*{5mm} Records marked as ineligible by\linebreak
\hspace*{5mm} automation tools (n = 0) \\ 
\hspace*{5mm} Records removed for other \\ 
\hspace*{5mm} reasons (n = 0)
}{};

\prismaflowarrow{n1}{n1r};

\prismaflownode{n2r}{right=2.5cm of n2}{
Records excluded (n = 128): \\
\hspace*{5mm} Exclusion Criterion 1 (n = 25) \\
\hspace*{5mm} Exclusion Criterion 2 (n = 5) \\
\hspace*{5mm} Exclusion Criterion 3 (n = 18) \\
\hspace*{5mm} Exclusion Criterion 4 (n = 17) \\
\hspace*{5mm} Exclusion Criterion 5 (n = 7) \\
\hspace*{5mm} Exclusion Criterion 6 (n = 8) \\
\hspace*{5mm} Exclusion Criterion 7 (n = 48) \\
\hspace*{5mm} Unrelated (noise) (n = 2)
}{};

\prismaflowarrow{n2}{n2r};

\prismaflownode{n3r}{right=2.5cm of n3}{
Reports not retrieved: (n = 0)
}{};

\prismaflowarrow{n3}{n3r};

\prismaflownode{n4r}{right=2.5cm of n4}{
Reports excluded (n = 15): \\
\hspace*{5mm} Exclusion Criterion 3 (n = 2) \\
\hspace*{5mm} Exclusion Criterion 6 (n = 1) \\
\hspace*{5mm} Redundant Contribution (n = 6) \\
\hspace*{5mm} Out of Scope (n = 4) \\
\hspace*{5mm} Insufficient methodology or lack of \\ \hspace*{5mm} scientific grounding (n = 2) \\
}{};

\prismaflowarrow{n4}{n4r};

% Phase labels

\prismalabelfitted{idbar}{n1}{n1r}{n1r}{Identification}
\prismalabelfitted{screenbar}{n2}{n2r}{n4r}{Screening}
\prismalabelfitted{incbar}{n5}{n5}{n5}{Included}

\prismaflowend
}
\caption{PRISMA 2020 flow diagram of the study selection process.}
\label{fig:prisma}
\end{figure}
```

<img width="781" height="832" alt="image" src="https://github.com/user-attachments/assets/67886d6d-9e58-4ab2-af98-e24d9d4758a5" />
